### PR TITLE
Refactor CLIP service to use CommonJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/services/clipService.js
+++ b/services/clipService.js
@@ -1,10 +1,10 @@
 
-import Replicate from "replicate";
+const Replicate = require("replicate");
 const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN
 });
 
-export async function getImageEmbedding(imageUrlOrBase64) {
+async function getImageEmbedding(imageUrlOrBase64) {
   const input = {
     image: imageUrlOrBase64
   };
@@ -27,9 +27,14 @@ export async function getImageEmbedding(imageUrlOrBase64) {
   }
 }
 
-export function cosineSimilarity(vecA, vecB) {
+function cosineSimilarity(vecA, vecB) {
   const dot = vecA.reduce((sum, a, i) => sum + a * vecB[i], 0);
   const normA = Math.sqrt(vecA.reduce((sum, a) => sum + a * a, 0));
   const normB = Math.sqrt(vecB.reduce((sum, b) => sum + b * b, 0));
   return dot / (normA * normB);
 }
+
+module.exports = {
+  getImageEmbedding,
+  cosineSimilarity
+};


### PR DESCRIPTION
## Summary
- replace ES module syntax in CLIP service with CommonJS
- add Git ignore for node_modules to keep repository clean

## Testing
- `node --check services/clipService.js`

------
https://chatgpt.com/codex/tasks/task_e_689a30406668832ea744167cfb398d59