### PR TITLE
Use new image upload endpoint with name field

### DIFF
--- a/frontend/scripts/upload.js
+++ b/frontend/scripts/upload.js
@@ -2,21 +2,27 @@
 // upload.js
 import { API_BASE } from './config.js';
 
-export async function uploadImage(label, base64Image, resultDiv, resetForm) {
+export async function uploadImage(name, base64Image, resultDiv, resetForm) {
   try {
-    const response = await fetch(`${API_BASE}/images`, {
+    const response = await fetch(`${API_BASE}/api/images/upload`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ label, image: base64Image })
+      body: JSON.stringify({ name, image: base64Image })
     });
 
     const data = await response.json();
-    resultDiv.innerHTML = data.success
-      ? `<p>✅ Imagem enviada com sucesso!</p>`
-      : `<p>❌ Erro: ${data.message}</p>`;
+    if (resultDiv) {
+      resultDiv.innerHTML = data.success
+        ? `<p>✅ Imagem enviada com sucesso!</p>`
+        : `<p>❌ Erro: ${data.message}</p>`;
+    }
     if (data.success && resetForm) resetForm();
+    return data;
   } catch (error) {
     console.error(error);
-    resultDiv.innerHTML = `<p>❌ Erro ao enviar.</p>`;
+    if (resultDiv) {
+      resultDiv.innerHTML = `<p>❌ Erro ao enviar.</p>`;
+    }
+    return { success: false, message: 'Erro ao enviar.' };
   }
 }

--- a/frontend/upload-image.html
+++ b/frontend/upload-image.html
@@ -65,7 +65,9 @@
     </button>
   </div>
 
-  <script>
+  <script type="module">
+    import { uploadImage } from "./scripts/upload.js";
+
     const dropZone = document.getElementById("dropZone");
     const fileInput = document.getElementById("fileInput");
     const previewContainer = document.getElementById("preview");
@@ -139,20 +141,8 @@
         console.log("Base64 inicia com:", base64Image?.substring(0, 30));
 
         try {
-          const res = await fetch("http://localhost:3001/api/images/upload", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json"
-            },
-            body: JSON.stringify({
-              name,
-              image: base64Image
-            })
-          });
-
-          const data = await res.json();
-
-          if (res.ok && data.success) {
+          const data = await uploadImage(name, base64Image);
+          if (data.success) {
             console.log("Imagem salva com embedding:", name);
             successCount++;
           } else {


### PR DESCRIPTION
## Summary
- point frontend upload utility at `${API_BASE}/api/images/upload`
- send `name` instead of `label` when uploading images
- import and use `uploadImage` helper in upload page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a30c85084832e8bb8ce1ab751f161