### PR TITLE
Refactor user pre-save hook to return promise

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -6,11 +6,10 @@ const userSchema = new mongoose.Schema({
   password: { type: String, required: true }
 }, { timestamps: true });
 
-userSchema.pre('save', async function (next) {
-  if (!this.isModified('password')) return next();
+userSchema.pre('save', async function () {
+  if (!this.isModified('password')) return;
   this.password = await bcrypt.hash(this.password, 10);
-  next();
-}, { timestamps: true });
+});
 
 userSchema.methods.comparePassword = function (candidatePassword) {
   return bcrypt.compare(candidatePassword, this.password);


### PR DESCRIPTION
## Summary
- simplify `User` model pre-save hook to rely on async promise instead of `next`
- remove extraneous `timestamps` option from pre hook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a30c861e8832e931af5245ab81f89